### PR TITLE
feat: Add outputs of release branch

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,7 @@ description: Release JavaScript actions
 inputs:
   version:
     # "pr/<pr number>", "latest" or "<tag>"
-    description: A released version. One of `pr/<pr number>`, `latest`, or tag vX.Y.Z. 
+    description: A released version. One of `pr/<pr number>`, `latest`, or tag vX.Y.Z.
     required: true
   pr:
     description: A pull request number
@@ -70,7 +70,7 @@ runs:
         echo "value=$value" >> "$GITHUB_OUTPUT"
       shell: bash
       id: current_branch
-    
+
     # Check if the branch exists
     - run: |
         value=false

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,10 @@ inputs:
       - pull_requests:write : Post comments to pull requests
     required: false
     default: ${{github.token}}
+outputs:
+  branch:
+    description: A branch name for a release
+    value: ${{steps.branch.outputs.value}}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
I added branch name (e.g. release-xxx) created by release-js-action to outputs. Because I would like to use it in my workflow.
ref. https://github.com/suzuki-shunsuke/mkghtag/issues/602#issuecomment-2626736419